### PR TITLE
Fix Unexpec[t]ed typo

### DIFF
--- a/library/src/main/java/net/jimblackler/jsonschemafriend/UnexpectedTypeError.java
+++ b/library/src/main/java/net/jimblackler/jsonschemafriend/UnexpectedTypeError.java
@@ -2,11 +2,11 @@ package net.jimblackler.jsonschemafriend;
 
 import java.net.URI;
 
-public class UnexpecedTypeError extends ValidationError {
+public class UnexpectedTypeError extends ValidationError {
   private final Object object;
   private final URI uri;
 
-  public UnexpecedTypeError(URI uri, Object document, Object object, Schema schema) {
+  public UnexpectedTypeError(URI uri, Object document, Object object, Schema schema) {
     super(uri, document, schema);
     this.uri = uri;
     this.object = object;

--- a/library/src/main/java/net/jimblackler/jsonschemafriend/Validator.java
+++ b/library/src/main/java/net/jimblackler/jsonschemafriend/Validator.java
@@ -542,7 +542,7 @@ public class Validator {
     } else if (object == null) {
       typeCheck(schema, document, uri, setOf("null"), disallow, errorConsumer);
     } else {
-      error.accept(new UnexpecedTypeError(uri, document, object, schema));
+      error.accept(new UnexpectedTypeError(uri, document, object, schema));
     }
 
     if (schema.hasConst()) {


### PR DESCRIPTION
This fixes a typo, by adding a missing 't' to the class name, Unexpec[t]edTypeError.