### PR TITLE
Allow alternative means of loading schemas

### DIFF
--- a/library/src/main/java/net/jimblackler/jsonschemafriend/CacheLoader.java
+++ b/library/src/main/java/net/jimblackler/jsonschemafriend/CacheLoader.java
@@ -11,11 +11,11 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.logging.Logger;
 
-public class CacheLoader {
+public class CacheLoader implements Loader {
   private static final Logger LOG = Logger.getLogger(CacheLoader.class.getName());
   private static final FileSystem FILE_SYSTEM = FileSystems.getDefault();
 
-  public static String load(URI uri, boolean cacheSchema) throws IOException {
+  public String load(URI uri, boolean cacheSchema) throws IOException {
     if (cacheSchema && ("http".equals(uri.getScheme()) || "https".equals(uri.getScheme()))) {
       Path diskCacheName = FILE_SYSTEM.getPath(System.getProperty("java.io.tmpdir"))
                                .resolve("net.jimblackler.jsonschemafriend")

--- a/library/src/main/java/net/jimblackler/jsonschemafriend/Loader.java
+++ b/library/src/main/java/net/jimblackler/jsonschemafriend/Loader.java
@@ -1,0 +1,8 @@
+package net.jimblackler.jsonschemafriend;
+
+import java.io.IOException;
+import java.net.URI;
+
+public interface Loader {
+    public String load(URI uri, boolean cacheSchema) throws IOException;
+}

--- a/library/src/main/java/net/jimblackler/jsonschemafriend/SchemaStore.java
+++ b/library/src/main/java/net/jimblackler/jsonschemafriend/SchemaStore.java
@@ -1,6 +1,5 @@
 package net.jimblackler.jsonschemafriend;
 
-import static net.jimblackler.jsonschemafriend.CacheLoader.load;
 import static net.jimblackler.jsonschemafriend.MetaSchemaDetector.detectMetaSchema;
 import static net.jimblackler.jsonschemafriend.MetaSchemaUris.DRAFT_3;
 import static net.jimblackler.jsonschemafriend.MetaSchemaUris.DRAFT_4;
@@ -44,25 +43,38 @@ public class SchemaStore {
   private final Map<URI, Set<String>> dynamicAnchorsBySchemaResource = new HashMap<>();
   private final Collection<URI> mapped = new HashSet<>();
   private final UrlRewriter urlRewriter;
+  private final Loader loader;
   private int memorySchemaNumber;
   private boolean cacheSchema;
 
   public SchemaStore() {
-    urlRewriter = null;
+    this(null, false);
   }
 
   public SchemaStore(boolean cacheSchema) {
-    this.cacheSchema = cacheSchema;
-    urlRewriter = null;
+    this(null, cacheSchema);
   }
 
   public SchemaStore(UrlRewriter urlRewriter) {
-    this.urlRewriter = urlRewriter;
+    this(urlRewriter, false);
+  }
+
+  public SchemaStore(Loader loader) {
+    this(null, false, loader);
+  }
+
+  public SchemaStore(UrlRewriter urlRewriter, Loader loader) {
+    this(urlRewriter, false, loader);
   }
 
   public SchemaStore(UrlRewriter urlRewriter, boolean cacheSchema) {
+    this(urlRewriter, cacheSchema, new CacheLoader());
+  }
+
+  public SchemaStore(UrlRewriter urlRewriter, boolean cacheSchema, Loader loader) {
     this.urlRewriter = urlRewriter;
     this.cacheSchema = cacheSchema;
+    this.loader = loader;
   }
 
   public Schema loadSchema(Object document) throws GenerationException {
@@ -224,9 +236,9 @@ public class SchemaStore {
 
   private String getContent(URI documentUri) throws IOException {
     if (urlRewriter == null) {
-      return load(documentUri, cacheSchema);
+      return loader.load(documentUri, cacheSchema);
     }
-    return load(urlRewriter.rewrite(documentUri), cacheSchema);
+    return loader.load(urlRewriter.rewrite(documentUri), cacheSchema);
   }
 
   public void register(URI path, Schema schema) throws GenerationException {


### PR DESCRIPTION
This is just a suggested change for a comment I raised in https://github.com/jimblackler/jsonschemafriend/issues/14 - don't know whether this is something you would consider.

The change is basically to remove the static CacheLoader.load method, and replace it with an interface 'Loader' instead. By default this would use the CacheLoader (so constructors are backwards compatible), but allow replacing with an alternative Loader if consumers of this library want to store files using alternative means.