### PR TITLE
pre-bundle all supported meta schemas in schema store

### DIFF
--- a/library/src/main/java/net/jimblackler/jsonschemafriend/MetaSchemaDetector.java
+++ b/library/src/main/java/net/jimblackler/jsonschemafriend/MetaSchemaDetector.java
@@ -1,8 +1,5 @@
 package net.jimblackler.jsonschemafriend;
 
-import static net.jimblackler.jsonschemafriend.MetaSchemaUris.DRAFT_4;
-import static net.jimblackler.jsonschemafriend.MetaSchemaUris.DRAFT_7;
-
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
@@ -11,7 +8,7 @@ import java.util.function.Consumer;
 public class MetaSchemaDetector {
   static URI detectMetaSchema(Object document) {
     if (document instanceof Boolean) {
-      return DRAFT_7;
+      return MetaSchemaUris.DRAFT_7;
     }
 
     if (document instanceof Map) {
@@ -23,6 +20,15 @@ public class MetaSchemaDetector {
         return URI.create((String) jsonDocument.get("schema"));
       }
     }
+
+    if (document instanceof List) {
+      List<Object> objects = (List<Object>) document;
+      if (objects.size() > 0) {
+        return detectMetaSchema(objects.get(0));
+      }
+      return MetaSchemaUris.DRAFT_2019_09;
+    }
+
     int[] idCount = {0};
     int[] dollarIdCount = {0};
     allKeys(document, key -> {
@@ -34,9 +40,9 @@ public class MetaSchemaDetector {
     });
 
     if (dollarIdCount[0] > idCount[0]) {
-      return DRAFT_7;
+      return MetaSchemaUris.DRAFT_7;
     }
-    return DRAFT_4;
+    return MetaSchemaUris.DRAFT_4;
   }
 
   private static void allKeys(Object document, Consumer<String> consumer) {

--- a/library/src/main/java/net/jimblackler/jsonschemafriend/MetaSchemaDraft03.java
+++ b/library/src/main/java/net/jimblackler/jsonschemafriend/MetaSchemaDraft03.java
@@ -1,0 +1,193 @@
+package net.jimblackler.jsonschemafriend;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+class MetaSchemaDraft03 {
+    private static final String SCHEMA_JSON = "{\n" +
+            "\t\"$schema\" : \"http://json-schema.org/draft-03/schema#\",\n" +
+            "\t\"id\" : \"http://json-schema.org/draft-03/schema#\",\n" +
+            "\t\"type\" : \"object\",\n" +
+            "\t\n" +
+            "\t\"properties\" : {\n" +
+            "\t\t\"type\" : {\n" +
+            "\t\t\t\"type\" : [\"string\", \"array\"],\n" +
+            "\t\t\t\"items\" : {\n" +
+            "\t\t\t\t\"type\" : [\"string\", {\"$ref\" : \"#\"}]\n" +
+            "\t\t\t},\n" +
+            "\t\t\t\"uniqueItems\" : true,\n" +
+            "\t\t\t\"default\" : \"any\"\n" +
+            "\t\t},\n" +
+            "\t\t\n" +
+            "\t\t\"properties\" : {\n" +
+            "\t\t\t\"type\" : \"object\",\n" +
+            "\t\t\t\"additionalProperties\" : {\"$ref\" : \"#\"},\n" +
+            "\t\t\t\"default\" : {}\n" +
+            "\t\t},\n" +
+            "\t\t\n" +
+            "\t\t\"patternProperties\" : {\n" +
+            "\t\t\t\"type\" : \"object\",\n" +
+            "\t\t\t\"additionalProperties\" : {\"$ref\" : \"#\"},\n" +
+            "\t\t\t\"default\" : {}\n" +
+            "\t\t},\n" +
+            "\t\t\n" +
+            "\t\t\"additionalProperties\" : {\n" +
+            "\t\t\t\"type\" : [{\"$ref\" : \"#\"}, \"boolean\"],\n" +
+            "\t\t\t\"default\" : {}\n" +
+            "\t\t},\n" +
+            "\t\t\n" +
+            "\t\t\"items\" : {\n" +
+            "\t\t\t\"type\" : [{\"$ref\" : \"#\"}, \"array\"],\n" +
+            "\t\t\t\"items\" : {\"$ref\" : \"#\"},\n" +
+            "\t\t\t\"default\" : {}\n" +
+            "\t\t},\n" +
+            "\t\t\n" +
+            "\t\t\"additionalItems\" : {\n" +
+            "\t\t\t\"type\" : [{\"$ref\" : \"#\"}, \"boolean\"],\n" +
+            "\t\t\t\"default\" : {}\n" +
+            "\t\t},\n" +
+            "\t\t\n" +
+            "\t\t\"required\" : {\n" +
+            "\t\t\t\"type\" : \"boolean\",\n" +
+            "\t\t\t\"default\" : false\n" +
+            "\t\t},\n" +
+            "\t\t\n" +
+            "\t\t\"dependencies\" : {\n" +
+            "\t\t\t\"type\" : \"object\",\n" +
+            "\t\t\t\"additionalProperties\" : {\n" +
+            "\t\t\t\t\"type\" : [\"string\", \"array\", {\"$ref\" : \"#\"}],\n" +
+            "\t\t\t\t\"items\" : {\n" +
+            "\t\t\t\t\t\"type\" : \"string\"\n" +
+            "\t\t\t\t}\n" +
+            "\t\t\t},\n" +
+            "\t\t\t\"default\" : {}\n" +
+            "\t\t},\n" +
+            "\t\t\n" +
+            "\t\t\"minimum\" : {\n" +
+            "\t\t\t\"type\" : \"number\"\n" +
+            "\t\t},\n" +
+            "\t\t\n" +
+            "\t\t\"maximum\" : {\n" +
+            "\t\t\t\"type\" : \"number\"\n" +
+            "\t\t},\n" +
+            "\t\t\n" +
+            "\t\t\"exclusiveMinimum\" : {\n" +
+            "\t\t\t\"type\" : \"boolean\",\n" +
+            "\t\t\t\"default\" : false\n" +
+            "\t\t},\n" +
+            "\t\t\n" +
+            "\t\t\"exclusiveMaximum\" : {\n" +
+            "\t\t\t\"type\" : \"boolean\",\n" +
+            "\t\t\t\"default\" : false\n" +
+            "\t\t},\n" +
+            "\t\t\n" +
+            "\t\t\"minItems\" : {\n" +
+            "\t\t\t\"type\" : \"integer\",\n" +
+            "\t\t\t\"minimum\" : 0,\n" +
+            "\t\t\t\"default\" : 0\n" +
+            "\t\t},\n" +
+            "\t\t\n" +
+            "\t\t\"maxItems\" : {\n" +
+            "\t\t\t\"type\" : \"integer\",\n" +
+            "\t\t\t\"minimum\" : 0\n" +
+            "\t\t},\n" +
+            "\t\t\n" +
+            "\t\t\"uniqueItems\" : {\n" +
+            "\t\t\t\"type\" : \"boolean\",\n" +
+            "\t\t\t\"default\" : false\n" +
+            "\t\t},\n" +
+            "\t\t\n" +
+            "\t\t\"pattern\" : {\n" +
+            "\t\t\t\"type\" : \"string\",\n" +
+            "\t\t\t\"format\" : \"regex\"\n" +
+            "\t\t},\n" +
+            "\t\t\n" +
+            "\t\t\"minLength\" : {\n" +
+            "\t\t\t\"type\" : \"integer\",\n" +
+            "\t\t\t\"minimum\" : 0,\n" +
+            "\t\t\t\"default\" : 0\n" +
+            "\t\t},\n" +
+            "\t\t\n" +
+            "\t\t\"maxLength\" : {\n" +
+            "\t\t\t\"type\" : \"integer\"\n" +
+            "\t\t},\n" +
+            "\t\t\n" +
+            "\t\t\"enum\" : {\n" +
+            "\t\t\t\"type\" : \"array\",\n" +
+            "\t\t\t\"minItems\" : 1,\n" +
+            "\t\t\t\"uniqueItems\" : true\n" +
+            "\t\t},\n" +
+            "\t\t\n" +
+            "\t\t\"default\" : {\n" +
+            "\t\t\t\"type\" : \"any\"\n" +
+            "\t\t},\n" +
+            "\t\t\n" +
+            "\t\t\"title\" : {\n" +
+            "\t\t\t\"type\" : \"string\"\n" +
+            "\t\t},\n" +
+            "\t\t\n" +
+            "\t\t\"description\" : {\n" +
+            "\t\t\t\"type\" : \"string\"\n" +
+            "\t\t},\n" +
+            "\t\t\n" +
+            "\t\t\"format\" : {\n" +
+            "\t\t\t\"type\" : \"string\"\n" +
+            "\t\t},\n" +
+            "\t\t\n" +
+            "\t\t\"divisibleBy\" : {\n" +
+            "\t\t\t\"type\" : \"number\",\n" +
+            "\t\t\t\"minimum\" : 0,\n" +
+            "\t\t\t\"exclusiveMinimum\" : true,\n" +
+            "\t\t\t\"default\" : 1\n" +
+            "\t\t},\n" +
+            "\t\t\n" +
+            "\t\t\"disallow\" : {\n" +
+            "\t\t\t\"type\" : [\"string\", \"array\"],\n" +
+            "\t\t\t\"items\" : {\n" +
+            "\t\t\t\t\"type\" : [\"string\", {\"$ref\" : \"#\"}]\n" +
+            "\t\t\t},\n" +
+            "\t\t\t\"uniqueItems\" : true\n" +
+            "\t\t},\n" +
+            "\t\t\n" +
+            "\t\t\"extends\" : {\n" +
+            "\t\t\t\"type\" : [{\"$ref\" : \"#\"}, \"array\"],\n" +
+            "\t\t\t\"items\" : {\"$ref\" : \"#\"},\n" +
+            "\t\t\t\"default\" : {}\n" +
+            "\t\t},\n" +
+            "\t\t\n" +
+            "\t\t\"id\" : {\n" +
+            "\t\t\t\"type\" : \"string\",\n" +
+            "\t\t\t\"format\" : \"uri\"\n" +
+            "\t\t},\n" +
+            "\t\t\n" +
+            "\t\t\"$ref\" : {\n" +
+            "\t\t\t\"type\" : \"string\",\n" +
+            "\t\t\t\"format\" : \"uri\"\n" +
+            "\t\t},\n" +
+            "\t\t\n" +
+            "\t\t\"$schema\" : {\n" +
+            "\t\t\t\"type\" : \"string\",\n" +
+            "\t\t\t\"format\" : \"uri\"\n" +
+            "\t\t}\n" +
+            "\t},\n" +
+            "\t\n" +
+            "\t\"dependencies\" : {\n" +
+            "\t\t\"exclusiveMinimum\" : \"minimum\",\n" +
+            "\t\t\"exclusiveMaximum\" : \"maximum\"\n" +
+            "\t},\n" +
+            "\t\n" +
+            "\t\"default\" : {}\n" +
+            "}";
+
+    static final Object SCHEMA;
+
+    static {
+        Object schemaObject;
+        try {
+            schemaObject = new ObjectMapper().readValue(SCHEMA_JSON, Object.class);
+        }
+        catch (Throwable ignored) {
+            schemaObject = null;
+        }
+        SCHEMA = schemaObject;
+    }
+}

--- a/library/src/main/java/net/jimblackler/jsonschemafriend/MetaSchemaDraft04.java
+++ b/library/src/main/java/net/jimblackler/jsonschemafriend/MetaSchemaDraft04.java
@@ -1,0 +1,168 @@
+package net.jimblackler.jsonschemafriend;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+class MetaSchemaDraft04 {
+    private static final String SCHEMA_JSON = "{\n" +
+            "    \"id\": \"http://json-schema.org/draft-04/schema#\",\n" +
+            "    \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n" +
+            "    \"description\": \"Core schema meta-schema\",\n" +
+            "    \"definitions\": {\n" +
+            "        \"schemaArray\": {\n" +
+            "            \"type\": \"array\",\n" +
+            "            \"minItems\": 1,\n" +
+            "            \"items\": { \"$ref\": \"#\" }\n" +
+            "        },\n" +
+            "        \"positiveInteger\": {\n" +
+            "            \"type\": \"integer\",\n" +
+            "            \"minimum\": 0\n" +
+            "        },\n" +
+            "        \"positiveIntegerDefault0\": {\n" +
+            "            \"allOf\": [ { \"$ref\": \"#/definitions/positiveInteger\" }, { \"default\": 0 } ]\n" +
+            "        },\n" +
+            "        \"simpleTypes\": {\n" +
+            "            \"enum\": [ \"array\", \"boolean\", \"integer\", \"null\", \"number\", \"object\", \"string\" ]\n" +
+            "        },\n" +
+            "        \"stringArray\": {\n" +
+            "            \"type\": \"array\",\n" +
+            "            \"items\": { \"type\": \"string\" },\n" +
+            "            \"minItems\": 1,\n" +
+            "            \"uniqueItems\": true\n" +
+            "        }\n" +
+            "    },\n" +
+            "    \"type\": \"object\",\n" +
+            "    \"properties\": {\n" +
+            "        \"id\": {\n" +
+            "            \"type\": \"string\"\n" +
+            "        },\n" +
+            "        \"$schema\": {\n" +
+            "            \"type\": \"string\"\n" +
+            "        },\n" +
+            "        \"title\": {\n" +
+            "            \"type\": \"string\"\n" +
+            "        },\n" +
+            "        \"description\": {\n" +
+            "            \"type\": \"string\"\n" +
+            "        },\n" +
+            "        \"default\": {},\n" +
+            "        \"multipleOf\": {\n" +
+            "            \"type\": \"number\",\n" +
+            "            \"minimum\": 0,\n" +
+            "            \"exclusiveMinimum\": true\n" +
+            "        },\n" +
+            "        \"maximum\": {\n" +
+            "            \"type\": \"number\"\n" +
+            "        },\n" +
+            "        \"exclusiveMaximum\": {\n" +
+            "            \"type\": \"boolean\",\n" +
+            "            \"default\": false\n" +
+            "        },\n" +
+            "        \"minimum\": {\n" +
+            "            \"type\": \"number\"\n" +
+            "        },\n" +
+            "        \"exclusiveMinimum\": {\n" +
+            "            \"type\": \"boolean\",\n" +
+            "            \"default\": false\n" +
+            "        },\n" +
+            "        \"maxLength\": { \"$ref\": \"#/definitions/positiveInteger\" },\n" +
+            "        \"minLength\": { \"$ref\": \"#/definitions/positiveIntegerDefault0\" },\n" +
+            "        \"pattern\": {\n" +
+            "            \"type\": \"string\",\n" +
+            "            \"format\": \"regex\"\n" +
+            "        },\n" +
+            "        \"additionalItems\": {\n" +
+            "            \"anyOf\": [\n" +
+            "                { \"type\": \"boolean\" },\n" +
+            "                { \"$ref\": \"#\" }\n" +
+            "            ],\n" +
+            "            \"default\": {}\n" +
+            "        },\n" +
+            "        \"items\": {\n" +
+            "            \"anyOf\": [\n" +
+            "                { \"$ref\": \"#\" },\n" +
+            "                { \"$ref\": \"#/definitions/schemaArray\" }\n" +
+            "            ],\n" +
+            "            \"default\": {}\n" +
+            "        },\n" +
+            "        \"maxItems\": { \"$ref\": \"#/definitions/positiveInteger\" },\n" +
+            "        \"minItems\": { \"$ref\": \"#/definitions/positiveIntegerDefault0\" },\n" +
+            "        \"uniqueItems\": {\n" +
+            "            \"type\": \"boolean\",\n" +
+            "            \"default\": false\n" +
+            "        },\n" +
+            "        \"maxProperties\": { \"$ref\": \"#/definitions/positiveInteger\" },\n" +
+            "        \"minProperties\": { \"$ref\": \"#/definitions/positiveIntegerDefault0\" },\n" +
+            "        \"required\": { \"$ref\": \"#/definitions/stringArray\" },\n" +
+            "        \"additionalProperties\": {\n" +
+            "            \"anyOf\": [\n" +
+            "                { \"type\": \"boolean\" },\n" +
+            "                { \"$ref\": \"#\" }\n" +
+            "            ],\n" +
+            "            \"default\": {}\n" +
+            "        },\n" +
+            "        \"definitions\": {\n" +
+            "            \"type\": \"object\",\n" +
+            "            \"additionalProperties\": { \"$ref\": \"#\" },\n" +
+            "            \"default\": {}\n" +
+            "        },\n" +
+            "        \"properties\": {\n" +
+            "            \"type\": \"object\",\n" +
+            "            \"additionalProperties\": { \"$ref\": \"#\" },\n" +
+            "            \"default\": {}\n" +
+            "        },\n" +
+            "        \"patternProperties\": {\n" +
+            "            \"type\": \"object\",\n" +
+            "            \"additionalProperties\": { \"$ref\": \"#\" },\n" +
+            "            \"default\": {}\n" +
+            "        },\n" +
+            "        \"dependencies\": {\n" +
+            "            \"type\": \"object\",\n" +
+            "            \"additionalProperties\": {\n" +
+            "                \"anyOf\": [\n" +
+            "                    { \"$ref\": \"#\" },\n" +
+            "                    { \"$ref\": \"#/definitions/stringArray\" }\n" +
+            "                ]\n" +
+            "            }\n" +
+            "        },\n" +
+            "        \"enum\": {\n" +
+            "            \"type\": \"array\",\n" +
+            "            \"minItems\": 1,\n" +
+            "            \"uniqueItems\": true\n" +
+            "        },\n" +
+            "        \"type\": {\n" +
+            "            \"anyOf\": [\n" +
+            "                { \"$ref\": \"#/definitions/simpleTypes\" },\n" +
+            "                {\n" +
+            "                    \"type\": \"array\",\n" +
+            "                    \"items\": { \"$ref\": \"#/definitions/simpleTypes\" },\n" +
+            "                    \"minItems\": 1,\n" +
+            "                    \"uniqueItems\": true\n" +
+            "                }\n" +
+            "            ]\n" +
+            "        },\n" +
+            "        \"format\": { \"type\": \"string\" },\n" +
+            "        \"allOf\": { \"$ref\": \"#/definitions/schemaArray\" },\n" +
+            "        \"anyOf\": { \"$ref\": \"#/definitions/schemaArray\" },\n" +
+            "        \"oneOf\": { \"$ref\": \"#/definitions/schemaArray\" },\n" +
+            "        \"not\": { \"$ref\": \"#\" }\n" +
+            "    },\n" +
+            "    \"dependencies\": {\n" +
+            "        \"exclusiveMaximum\": [ \"maximum\" ],\n" +
+            "        \"exclusiveMinimum\": [ \"minimum\" ]\n" +
+            "    },\n" +
+            "    \"default\": {}\n" +
+            "}";
+
+    static final Object SCHEMA;
+
+    static {
+        Object schemaObject;
+        try {
+            schemaObject = new ObjectMapper().readValue(SCHEMA_JSON, Object.class);
+        }
+        catch (Throwable ignored) {
+            schemaObject = null;
+        }
+        SCHEMA = schemaObject;
+    }
+}

--- a/library/src/main/java/net/jimblackler/jsonschemafriend/MetaSchemaDraft06.java
+++ b/library/src/main/java/net/jimblackler/jsonschemafriend/MetaSchemaDraft06.java
@@ -1,0 +1,174 @@
+package net.jimblackler.jsonschemafriend;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+class MetaSchemaDraft06 {
+    private static final String SCHEMA_JSON = "{\n" +
+            "    \"$schema\": \"http://json-schema.org/draft-06/schema#\",\n" +
+            "    \"$id\": \"http://json-schema.org/draft-06/schema#\",\n" +
+            "    \"title\": \"Core schema meta-schema\",\n" +
+            "    \"definitions\": {\n" +
+            "        \"schemaArray\": {\n" +
+            "            \"type\": \"array\",\n" +
+            "            \"minItems\": 1,\n" +
+            "            \"items\": { \"$ref\": \"#\" }\n" +
+            "        },\n" +
+            "        \"nonNegativeInteger\": {\n" +
+            "            \"type\": \"integer\",\n" +
+            "            \"minimum\": 0\n" +
+            "        },\n" +
+            "        \"nonNegativeIntegerDefault0\": {\n" +
+            "            \"allOf\": [\n" +
+            "                { \"$ref\": \"#/definitions/nonNegativeInteger\" },\n" +
+            "                { \"default\": 0 }\n" +
+            "            ]\n" +
+            "        },\n" +
+            "        \"simpleTypes\": {\n" +
+            "            \"enum\": [\n" +
+            "                \"array\",\n" +
+            "                \"boolean\",\n" +
+            "                \"integer\",\n" +
+            "                \"null\",\n" +
+            "                \"number\",\n" +
+            "                \"object\",\n" +
+            "                \"string\"\n" +
+            "            ]\n" +
+            "        },\n" +
+            "        \"stringArray\": {\n" +
+            "            \"type\": \"array\",\n" +
+            "            \"items\": { \"type\": \"string\" },\n" +
+            "            \"uniqueItems\": true,\n" +
+            "            \"default\": []\n" +
+            "        }\n" +
+            "    },\n" +
+            "    \"type\": [\"object\", \"boolean\"],\n" +
+            "    \"properties\": {\n" +
+            "        \"$id\": {\n" +
+            "            \"type\": \"string\",\n" +
+            "            \"format\": \"uri-reference\"\n" +
+            "        },\n" +
+            "        \"$schema\": {\n" +
+            "            \"type\": \"string\",\n" +
+            "            \"format\": \"uri\"\n" +
+            "        },\n" +
+            "        \"$ref\": {\n" +
+            "            \"type\": \"string\",\n" +
+            "            \"format\": \"uri-reference\"\n" +
+            "        },\n" +
+            "        \"title\": {\n" +
+            "            \"type\": \"string\"\n" +
+            "        },\n" +
+            "        \"description\": {\n" +
+            "            \"type\": \"string\"\n" +
+            "        },\n" +
+            "        \"default\": {},\n" +
+            "        \"examples\": {\n" +
+            "            \"type\": \"array\",\n" +
+            "            \"items\": {}\n" +
+            "        },\n" +
+            "        \"multipleOf\": {\n" +
+            "            \"type\": \"number\",\n" +
+            "            \"exclusiveMinimum\": 0\n" +
+            "        },\n" +
+            "        \"maximum\": {\n" +
+            "            \"type\": \"number\"\n" +
+            "        },\n" +
+            "        \"exclusiveMaximum\": {\n" +
+            "            \"type\": \"number\"\n" +
+            "        },\n" +
+            "        \"minimum\": {\n" +
+            "            \"type\": \"number\"\n" +
+            "        },\n" +
+            "        \"exclusiveMinimum\": {\n" +
+            "            \"type\": \"number\"\n" +
+            "        },\n" +
+            "        \"maxLength\": { \"$ref\": \"#/definitions/nonNegativeInteger\" },\n" +
+            "        \"minLength\": { \"$ref\": \"#/definitions/nonNegativeIntegerDefault0\" },\n" +
+            "        \"pattern\": {\n" +
+            "            \"type\": \"string\",\n" +
+            "            \"format\": \"regex\"\n" +
+            "        },\n" +
+            "        \"additionalItems\": { \"$ref\": \"#\" },\n" +
+            "        \"items\": {\n" +
+            "            \"anyOf\": [\n" +
+            "                { \"$ref\": \"#\" },\n" +
+            "                { \"$ref\": \"#/definitions/schemaArray\" }\n" +
+            "            ],\n" +
+            "            \"default\": {}\n" +
+            "        },\n" +
+            "        \"maxItems\": { \"$ref\": \"#/definitions/nonNegativeInteger\" },\n" +
+            "        \"minItems\": { \"$ref\": \"#/definitions/nonNegativeIntegerDefault0\" },\n" +
+            "        \"uniqueItems\": {\n" +
+            "            \"type\": \"boolean\",\n" +
+            "            \"default\": false\n" +
+            "        },\n" +
+            "        \"contains\": { \"$ref\": \"#\" },\n" +
+            "        \"maxProperties\": { \"$ref\": \"#/definitions/nonNegativeInteger\" },\n" +
+            "        \"minProperties\": { \"$ref\": \"#/definitions/nonNegativeIntegerDefault0\" },\n" +
+            "        \"required\": { \"$ref\": \"#/definitions/stringArray\" },\n" +
+            "        \"additionalProperties\": { \"$ref\": \"#\" },\n" +
+            "        \"definitions\": {\n" +
+            "            \"type\": \"object\",\n" +
+            "            \"additionalProperties\": { \"$ref\": \"#\" },\n" +
+            "            \"default\": {}\n" +
+            "        },\n" +
+            "        \"properties\": {\n" +
+            "            \"type\": \"object\",\n" +
+            "            \"additionalProperties\": { \"$ref\": \"#\" },\n" +
+            "            \"default\": {}\n" +
+            "        },\n" +
+            "        \"patternProperties\": {\n" +
+            "            \"type\": \"object\",\n" +
+            "            \"additionalProperties\": { \"$ref\": \"#\" },\n" +
+            "            \"propertyNames\": { \"format\": \"regex\" },\n" +
+            "            \"default\": {}\n" +
+            "        },\n" +
+            "        \"dependencies\": {\n" +
+            "            \"type\": \"object\",\n" +
+            "            \"additionalProperties\": {\n" +
+            "                \"anyOf\": [\n" +
+            "                    { \"$ref\": \"#\" },\n" +
+            "                    { \"$ref\": \"#/definitions/stringArray\" }\n" +
+            "                ]\n" +
+            "            }\n" +
+            "        },\n" +
+            "        \"propertyNames\": { \"$ref\": \"#\" },\n" +
+            "        \"const\": {},\n" +
+            "        \"enum\": {\n" +
+            "            \"type\": \"array\",\n" +
+            "            \"minItems\": 1,\n" +
+            "            \"uniqueItems\": true\n" +
+            "        },\n" +
+            "        \"type\": {\n" +
+            "            \"anyOf\": [\n" +
+            "                { \"$ref\": \"#/definitions/simpleTypes\" },\n" +
+            "                {\n" +
+            "                    \"type\": \"array\",\n" +
+            "                    \"items\": { \"$ref\": \"#/definitions/simpleTypes\" },\n" +
+            "                    \"minItems\": 1,\n" +
+            "                    \"uniqueItems\": true\n" +
+            "                }\n" +
+            "            ]\n" +
+            "        },\n" +
+            "        \"format\": { \"type\": \"string\" },\n" +
+            "        \"allOf\": { \"$ref\": \"#/definitions/schemaArray\" },\n" +
+            "        \"anyOf\": { \"$ref\": \"#/definitions/schemaArray\" },\n" +
+            "        \"oneOf\": { \"$ref\": \"#/definitions/schemaArray\" },\n" +
+            "        \"not\": { \"$ref\": \"#\" }\n" +
+            "    },\n" +
+            "    \"default\": {}\n" +
+            "}";
+
+    static final Object SCHEMA;
+
+    static {
+        Object schemaObject;
+        try {
+            schemaObject = new ObjectMapper().readValue(SCHEMA_JSON, Object.class);
+        }
+        catch (Throwable ignored) {
+            schemaObject = null;
+        }
+        SCHEMA = schemaObject;
+    }
+}

--- a/library/src/main/java/net/jimblackler/jsonschemafriend/MetaSchemaDraft07.java
+++ b/library/src/main/java/net/jimblackler/jsonschemafriend/MetaSchemaDraft07.java
@@ -1,0 +1,191 @@
+package net.jimblackler.jsonschemafriend;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+class MetaSchemaDraft07 {
+    private static final String SCHEMA_JSON = "{\n" +
+            "    \"$schema\": \"http://json-schema.org/draft-07/schema#\",\n" +
+            "    \"$id\": \"http://json-schema.org/draft-07/schema#\",\n" +
+            "    \"title\": \"Core schema meta-schema\",\n" +
+            "    \"definitions\": {\n" +
+            "        \"schemaArray\": {\n" +
+            "            \"type\": \"array\",\n" +
+            "            \"minItems\": 1,\n" +
+            "            \"items\": { \"$ref\": \"#\" }\n" +
+            "        },\n" +
+            "        \"nonNegativeInteger\": {\n" +
+            "            \"type\": \"integer\",\n" +
+            "            \"minimum\": 0\n" +
+            "        },\n" +
+            "        \"nonNegativeIntegerDefault0\": {\n" +
+            "            \"allOf\": [\n" +
+            "                { \"$ref\": \"#/definitions/nonNegativeInteger\" },\n" +
+            "                { \"default\": 0 }\n" +
+            "            ]\n" +
+            "        },\n" +
+            "        \"simpleTypes\": {\n" +
+            "            \"enum\": [\n" +
+            "                \"array\",\n" +
+            "                \"boolean\",\n" +
+            "                \"integer\",\n" +
+            "                \"null\",\n" +
+            "                \"number\",\n" +
+            "                \"object\",\n" +
+            "                \"string\"\n" +
+            "            ]\n" +
+            "        },\n" +
+            "        \"stringArray\": {\n" +
+            "            \"type\": \"array\",\n" +
+            "            \"items\": { \"type\": \"string\" },\n" +
+            "            \"uniqueItems\": true,\n" +
+            "            \"default\": []\n" +
+            "        }\n" +
+            "    },\n" +
+            "    \"type\": [\"object\", \"boolean\"],\n" +
+            "    \"properties\": {\n" +
+            "        \"$id\": {\n" +
+            "            \"type\": \"string\",\n" +
+            "            \"format\": \"uri-reference\"\n" +
+            "        },\n" +
+            "        \"$schema\": {\n" +
+            "            \"type\": \"string\",\n" +
+            "            \"format\": \"uri\"\n" +
+            "        },\n" +
+            "        \"$ref\": {\n" +
+            "            \"type\": \"string\",\n" +
+            "            \"format\": \"uri-reference\"\n" +
+            "        },\n" +
+            "        \"$comment\": {\n" +
+            "            \"type\": \"string\"\n" +
+            "        },\n" +
+            "        \"title\": {\n" +
+            "            \"type\": \"string\"\n" +
+            "        },\n" +
+            "        \"description\": {\n" +
+            "            \"type\": \"string\"\n" +
+            "        },\n" +
+            "        \"default\": true,\n" +
+            "        \"readOnly\": {\n" +
+            "            \"type\": \"boolean\",\n" +
+            "            \"default\": false\n" +
+            "        },\n" +
+            "        \"writeOnly\": {\n" +
+            "            \"type\": \"boolean\",\n" +
+            "            \"default\": false\n" +
+            "        },\n" +
+            "        \"examples\": {\n" +
+            "            \"type\": \"array\",\n" +
+            "            \"items\": true\n" +
+            "        },\n" +
+            "        \"multipleOf\": {\n" +
+            "            \"type\": \"number\",\n" +
+            "            \"exclusiveMinimum\": 0\n" +
+            "        },\n" +
+            "        \"maximum\": {\n" +
+            "            \"type\": \"number\"\n" +
+            "        },\n" +
+            "        \"exclusiveMaximum\": {\n" +
+            "            \"type\": \"number\"\n" +
+            "        },\n" +
+            "        \"minimum\": {\n" +
+            "            \"type\": \"number\"\n" +
+            "        },\n" +
+            "        \"exclusiveMinimum\": {\n" +
+            "            \"type\": \"number\"\n" +
+            "        },\n" +
+            "        \"maxLength\": { \"$ref\": \"#/definitions/nonNegativeInteger\" },\n" +
+            "        \"minLength\": { \"$ref\": \"#/definitions/nonNegativeIntegerDefault0\" },\n" +
+            "        \"pattern\": {\n" +
+            "            \"type\": \"string\",\n" +
+            "            \"format\": \"regex\"\n" +
+            "        },\n" +
+            "        \"additionalItems\": { \"$ref\": \"#\" },\n" +
+            "        \"items\": {\n" +
+            "            \"anyOf\": [\n" +
+            "                { \"$ref\": \"#\" },\n" +
+            "                { \"$ref\": \"#/definitions/schemaArray\" }\n" +
+            "            ],\n" +
+            "            \"default\": true\n" +
+            "        },\n" +
+            "        \"maxItems\": { \"$ref\": \"#/definitions/nonNegativeInteger\" },\n" +
+            "        \"minItems\": { \"$ref\": \"#/definitions/nonNegativeIntegerDefault0\" },\n" +
+            "        \"uniqueItems\": {\n" +
+            "            \"type\": \"boolean\",\n" +
+            "            \"default\": false\n" +
+            "        },\n" +
+            "        \"contains\": { \"$ref\": \"#\" },\n" +
+            "        \"maxProperties\": { \"$ref\": \"#/definitions/nonNegativeInteger\" },\n" +
+            "        \"minProperties\": { \"$ref\": \"#/definitions/nonNegativeIntegerDefault0\" },\n" +
+            "        \"required\": { \"$ref\": \"#/definitions/stringArray\" },\n" +
+            "        \"additionalProperties\": { \"$ref\": \"#\" },\n" +
+            "        \"definitions\": {\n" +
+            "            \"type\": \"object\",\n" +
+            "            \"additionalProperties\": { \"$ref\": \"#\" },\n" +
+            "            \"default\": {}\n" +
+            "        },\n" +
+            "        \"properties\": {\n" +
+            "            \"type\": \"object\",\n" +
+            "            \"additionalProperties\": { \"$ref\": \"#\" },\n" +
+            "            \"default\": {}\n" +
+            "        },\n" +
+            "        \"patternProperties\": {\n" +
+            "            \"type\": \"object\",\n" +
+            "            \"additionalProperties\": { \"$ref\": \"#\" },\n" +
+            "            \"propertyNames\": { \"format\": \"regex\" },\n" +
+            "            \"default\": {}\n" +
+            "        },\n" +
+            "        \"dependencies\": {\n" +
+            "            \"type\": \"object\",\n" +
+            "            \"additionalProperties\": {\n" +
+            "                \"anyOf\": [\n" +
+            "                    { \"$ref\": \"#\" },\n" +
+            "                    { \"$ref\": \"#/definitions/stringArray\" }\n" +
+            "                ]\n" +
+            "            }\n" +
+            "        },\n" +
+            "        \"propertyNames\": { \"$ref\": \"#\" },\n" +
+            "        \"const\": true,\n" +
+            "        \"enum\": {\n" +
+            "            \"type\": \"array\",\n" +
+            "            \"items\": true,\n" +
+            "            \"minItems\": 1,\n" +
+            "            \"uniqueItems\": true\n" +
+            "        },\n" +
+            "        \"type\": {\n" +
+            "            \"anyOf\": [\n" +
+            "                { \"$ref\": \"#/definitions/simpleTypes\" },\n" +
+            "                {\n" +
+            "                    \"type\": \"array\",\n" +
+            "                    \"items\": { \"$ref\": \"#/definitions/simpleTypes\" },\n" +
+            "                    \"minItems\": 1,\n" +
+            "                    \"uniqueItems\": true\n" +
+            "                }\n" +
+            "            ]\n" +
+            "        },\n" +
+            "        \"format\": { \"type\": \"string\" },\n" +
+            "        \"contentMediaType\": { \"type\": \"string\" },\n" +
+            "        \"contentEncoding\": { \"type\": \"string\" },\n" +
+            "        \"if\": { \"$ref\": \"#\" },\n" +
+            "        \"then\": { \"$ref\": \"#\" },\n" +
+            "        \"else\": { \"$ref\": \"#\" },\n" +
+            "        \"allOf\": { \"$ref\": \"#/definitions/schemaArray\" },\n" +
+            "        \"anyOf\": { \"$ref\": \"#/definitions/schemaArray\" },\n" +
+            "        \"oneOf\": { \"$ref\": \"#/definitions/schemaArray\" },\n" +
+            "        \"not\": { \"$ref\": \"#\" }\n" +
+            "    },\n" +
+            "    \"default\": true\n" +
+            "}";
+
+    static final Object SCHEMA;
+
+    static {
+        Object schemaObject;
+        try {
+            schemaObject = new ObjectMapper().readValue(SCHEMA_JSON, Object.class);
+        }
+        catch (Throwable ignored) {
+            schemaObject = null;
+        }
+        SCHEMA = schemaObject;
+    }
+}

--- a/library/src/main/java/net/jimblackler/jsonschemafriend/MetaSchemaDraft201909.java
+++ b/library/src/main/java/net/jimblackler/jsonschemafriend/MetaSchemaDraft201909.java
@@ -1,0 +1,339 @@
+package net.jimblackler.jsonschemafriend;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+class MetaSchemaDraft201909 {
+    private static final String[] SCHEMA_JSONS = new String[] {
+            "{\n" +
+                    "  \"$schema\": \"https://json-schema.org/draft/2019-09/schema\",\n" +
+                    "  \"$id\": \"https://json-schema.org/draft/2019-09/schema\",\n" +
+                    "  \"$vocabulary\": {\n" +
+                    "    \"https://json-schema.org/draft/2019-09/vocab/core\": true,\n" +
+                    "    \"https://json-schema.org/draft/2019-09/vocab/applicator\": true,\n" +
+                    "    \"https://json-schema.org/draft/2019-09/vocab/validation\": true,\n" +
+                    "    \"https://json-schema.org/draft/2019-09/vocab/meta-data\": true,\n" +
+                    "    \"https://json-schema.org/draft/2019-09/vocab/format\": false,\n" +
+                    "    \"https://json-schema.org/draft/2019-09/vocab/content\": true\n" +
+                    "  },\n" +
+                    "  \"$recursiveAnchor\": true,\n" +
+                    "\n" +
+                    "  \"title\": \"Core and Validation specifications meta-schema\",\n" +
+                    "  \"allOf\": [\n" +
+                    "    {\"$ref\": \"meta/core\"},\n" +
+                    "    {\"$ref\": \"meta/applicator\"},\n" +
+                    "    {\"$ref\": \"meta/validation\"},\n" +
+                    "    {\"$ref\": \"meta/meta-data\"},\n" +
+                    "    {\"$ref\": \"meta/format\"},\n" +
+                    "    {\"$ref\": \"meta/content\"}\n" +
+                    "  ],\n" +
+                    "  \"type\": [\"object\", \"boolean\"],\n" +
+                    "  \"properties\": {\n" +
+                    "    \"definitions\": {\n" +
+                    "      \"$comment\": \"While no longer an official keyword as it is replaced by $defs, this keyword is retained in the meta-schema to prevent incompatible extensions as it remains in common use.\",\n" +
+                    "      \"type\": \"object\",\n" +
+                    "      \"additionalProperties\": {\"$recursiveRef\": \"#\"},\n" +
+                    "      \"default\": {}\n" +
+                    "    },\n" +
+                    "    \"dependencies\": {\n" +
+                    "      \"$comment\": \"\\\"dependencies\\\" is no longer a keyword, but schema authors should avoid redefining it to facilitate a smooth transition to \\\"dependentSchemas\\\" and \\\"dependentRequired\\\"\",\n" +
+                    "      \"type\": \"object\",\n" +
+                    "      \"additionalProperties\": {\n" +
+                    "        \"anyOf\": [{\"$recursiveRef\": \"#\"}, {\"$ref\": \"meta/validation#/$defs/stringArray\"}]\n" +
+                    "      }\n" +
+                    "    }\n" +
+                    "  }\n" +
+                    "}\n",
+            "{\n" +
+                    "  \"$schema\": \"https://json-schema.org/draft/2019-09/schema\",\n" +
+                    "  \"$id\": \"https://json-schema.org/draft/2019-09/meta/applicator\",\n" +
+                    "  \"$vocabulary\": {\n" +
+                    "    \"https://json-schema.org/draft/2019-09/vocab/applicator\": true\n" +
+                    "  },\n" +
+                    "  \"$recursiveAnchor\": true,\n" +
+                    "\n" +
+                    "  \"title\": \"Applicator vocabulary meta-schema\",\n" +
+                    "  \"type\": [\"object\", \"boolean\"],\n" +
+                    "  \"properties\": {\n" +
+                    "    \"additionalItems\": {\"$recursiveRef\": \"#\"},\n" +
+                    "    \"unevaluatedItems\": {\"$recursiveRef\": \"#\"},\n" +
+                    "    \"items\": {\n" +
+                    "      \"anyOf\": [{\"$recursiveRef\": \"#\"}, {\"$ref\": \"#/$defs/schemaArray\"}]\n" +
+                    "    },\n" +
+                    "    \"contains\": {\"$recursiveRef\": \"#\"},\n" +
+                    "    \"additionalProperties\": {\"$recursiveRef\": \"#\"},\n" +
+                    "    \"unevaluatedProperties\": {\"$recursiveRef\": \"#\"},\n" +
+                    "    \"properties\": {\n" +
+                    "      \"type\": \"object\",\n" +
+                    "      \"additionalProperties\": {\"$recursiveRef\": \"#\"},\n" +
+                    "      \"default\": {}\n" +
+                    "    },\n" +
+                    "    \"patternProperties\": {\n" +
+                    "      \"type\": \"object\",\n" +
+                    "      \"additionalProperties\": {\"$recursiveRef\": \"#\"},\n" +
+                    "      \"propertyNames\": {\"format\": \"regex\"},\n" +
+                    "      \"default\": {}\n" +
+                    "    },\n" +
+                    "    \"dependentSchemas\": {\n" +
+                    "      \"type\": \"object\",\n" +
+                    "      \"additionalProperties\": {\n" +
+                    "        \"$recursiveRef\": \"#\"\n" +
+                    "      }\n" +
+                    "    },\n" +
+                    "    \"propertyNames\": {\"$recursiveRef\": \"#\"},\n" +
+                    "    \"if\": {\"$recursiveRef\": \"#\"},\n" +
+                    "    \"then\": {\"$recursiveRef\": \"#\"},\n" +
+                    "    \"else\": {\"$recursiveRef\": \"#\"},\n" +
+                    "    \"allOf\": {\"$ref\": \"#/$defs/schemaArray\"},\n" +
+                    "    \"anyOf\": {\"$ref\": \"#/$defs/schemaArray\"},\n" +
+                    "    \"oneOf\": {\"$ref\": \"#/$defs/schemaArray\"},\n" +
+                    "    \"not\": {\"$recursiveRef\": \"#\"}\n" +
+                    "  },\n" +
+                    "  \"$defs\": {\n" +
+                    "    \"schemaArray\": {\n" +
+                    "      \"type\": \"array\",\n" +
+                    "      \"minItems\": 1,\n" +
+                    "      \"items\": {\"$recursiveRef\": \"#\"}\n" +
+                    "    }\n" +
+                    "  }\n" +
+                    "}\n",
+            "{\n" +
+                    "  \"$schema\": \"https://json-schema.org/draft/2019-09/schema\",\n" +
+                    "  \"$id\": \"https://json-schema.org/draft/2019-09/meta/content\",\n" +
+                    "  \"$vocabulary\": {\n" +
+                    "    \"https://json-schema.org/draft/2019-09/vocab/content\": true\n" +
+                    "  },\n" +
+                    "  \"$recursiveAnchor\": true,\n" +
+                    "\n" +
+                    "  \"title\": \"Content vocabulary meta-schema\",\n" +
+                    "\n" +
+                    "  \"type\": [\"object\", \"boolean\"],\n" +
+                    "  \"properties\": {\n" +
+                    "    \"contentMediaType\": {\"type\": \"string\"},\n" +
+                    "    \"contentEncoding\": {\"type\": \"string\"},\n" +
+                    "    \"contentSchema\": {\"$recursiveRef\": \"#\"}\n" +
+                    "  }\n" +
+                    "}\n",
+            "{\n" +
+                    "  \"$schema\": \"https://json-schema.org/draft/2019-09/schema\",\n" +
+                    "  \"$id\": \"https://json-schema.org/draft/2019-09/meta/core\",\n" +
+                    "  \"$vocabulary\": {\n" +
+                    "    \"https://json-schema.org/draft/2019-09/vocab/core\": true\n" +
+                    "  },\n" +
+                    "  \"$recursiveAnchor\": true,\n" +
+                    "\n" +
+                    "  \"title\": \"Core vocabulary meta-schema\",\n" +
+                    "  \"type\": [\"object\", \"boolean\"],\n" +
+                    "  \"properties\": {\n" +
+                    "    \"$id\": {\n" +
+                    "      \"type\": \"string\",\n" +
+                    "      \"format\": \"uri-reference\",\n" +
+                    "      \"$comment\": \"Non-empty fragments not allowed.\",\n" +
+                    "      \"pattern\": \"^[^#]*#?$\"\n" +
+                    "    },\n" +
+                    "    \"$schema\": {\n" +
+                    "      \"type\": \"string\",\n" +
+                    "      \"format\": \"uri\"\n" +
+                    "    },\n" +
+                    "    \"$anchor\": {\n" +
+                    "      \"type\": \"string\",\n" +
+                    "      \"pattern\": \"^[A-Za-z][-A-Za-z0-9.:_]*$\"\n" +
+                    "    },\n" +
+                    "    \"$ref\": {\n" +
+                    "      \"type\": \"string\",\n" +
+                    "      \"format\": \"uri-reference\"\n" +
+                    "    },\n" +
+                    "    \"$recursiveRef\": {\n" +
+                    "      \"type\": \"string\",\n" +
+                    "      \"format\": \"uri-reference\"\n" +
+                    "    },\n" +
+                    "    \"$recursiveAnchor\": {\n" +
+                    "      \"type\": \"boolean\",\n" +
+                    "      \"default\": false\n" +
+                    "    },\n" +
+                    "    \"$vocabulary\": {\n" +
+                    "      \"type\": \"object\",\n" +
+                    "      \"propertyNames\": {\n" +
+                    "        \"type\": \"string\",\n" +
+                    "        \"format\": \"uri\"\n" +
+                    "      },\n" +
+                    "      \"additionalProperties\": {\n" +
+                    "        \"type\": \"boolean\"\n" +
+                    "      }\n" +
+                    "    },\n" +
+                    "    \"$comment\": {\n" +
+                    "      \"type\": \"string\"\n" +
+                    "    },\n" +
+                    "    \"$defs\": {\n" +
+                    "      \"type\": \"object\",\n" +
+                    "      \"additionalProperties\": {\"$recursiveRef\": \"#\"},\n" +
+                    "      \"default\": {}\n" +
+                    "    }\n" +
+                    "  }\n" +
+                    "}\n",
+            "{\n" +
+                    "  \"$schema\": \"https://json-schema.org/draft/2019-09/schema\",\n" +
+                    "  \"$id\": \"https://json-schema.org/draft/2019-09/meta/format\",\n" +
+                    "  \"$vocabulary\": {\n" +
+                    "    \"https://json-schema.org/draft/2019-09/vocab/format\": true\n" +
+                    "  },\n" +
+                    "  \"$recursiveAnchor\": true,\n" +
+                    "\n" +
+                    "  \"title\": \"Format vocabulary meta-schema\",\n" +
+                    "  \"type\": [\"object\", \"boolean\"],\n" +
+                    "  \"properties\": {\n" +
+                    "    \"format\": {\"type\": \"string\"}\n" +
+                    "  }\n" +
+                    "}\n",
+            "{\n" +
+                    "  \"$schema\": \"https://json-schema.org/draft/2019-09/schema\",\n" +
+                    "  \"$id\": \"https://json-schema.org/draft/2019-09/meta/meta-data\",\n" +
+                    "  \"$vocabulary\": {\n" +
+                    "    \"https://json-schema.org/draft/2019-09/vocab/meta-data\": true\n" +
+                    "  },\n" +
+                    "  \"$recursiveAnchor\": true,\n" +
+                    "\n" +
+                    "  \"title\": \"Meta-data vocabulary meta-schema\",\n" +
+                    "\n" +
+                    "  \"type\": [\"object\", \"boolean\"],\n" +
+                    "  \"properties\": {\n" +
+                    "    \"title\": {\n" +
+                    "      \"type\": \"string\"\n" +
+                    "    },\n" +
+                    "    \"description\": {\n" +
+                    "      \"type\": \"string\"\n" +
+                    "    },\n" +
+                    "    \"default\": true,\n" +
+                    "    \"deprecated\": {\n" +
+                    "      \"type\": \"boolean\",\n" +
+                    "      \"default\": false\n" +
+                    "    },\n" +
+                    "    \"readOnly\": {\n" +
+                    "      \"type\": \"boolean\",\n" +
+                    "      \"default\": false\n" +
+                    "    },\n" +
+                    "    \"writeOnly\": {\n" +
+                    "      \"type\": \"boolean\",\n" +
+                    "      \"default\": false\n" +
+                    "    },\n" +
+                    "    \"examples\": {\n" +
+                    "      \"type\": \"array\",\n" +
+                    "      \"items\": true\n" +
+                    "    }\n" +
+                    "  }\n" +
+                    "}\n",
+            "{\n" +
+                    "  \"$schema\": \"https://json-schema.org/draft/2019-09/schema\",\n" +
+                    "  \"$id\": \"https://json-schema.org/draft/2019-09/meta/validation\",\n" +
+                    "  \"$vocabulary\": {\n" +
+                    "    \"https://json-schema.org/draft/2019-09/vocab/validation\": true\n" +
+                    "  },\n" +
+                    "  \"$recursiveAnchor\": true,\n" +
+                    "\n" +
+                    "  \"title\": \"Validation vocabulary meta-schema\",\n" +
+                    "  \"type\": [\"object\", \"boolean\"],\n" +
+                    "  \"properties\": {\n" +
+                    "    \"multipleOf\": {\n" +
+                    "      \"type\": \"number\",\n" +
+                    "      \"exclusiveMinimum\": 0\n" +
+                    "    },\n" +
+                    "    \"maximum\": {\n" +
+                    "      \"type\": \"number\"\n" +
+                    "    },\n" +
+                    "    \"exclusiveMaximum\": {\n" +
+                    "      \"type\": \"number\"\n" +
+                    "    },\n" +
+                    "    \"minimum\": {\n" +
+                    "      \"type\": \"number\"\n" +
+                    "    },\n" +
+                    "    \"exclusiveMinimum\": {\n" +
+                    "      \"type\": \"number\"\n" +
+                    "    },\n" +
+                    "    \"maxLength\": {\"$ref\": \"#/$defs/nonNegativeInteger\"},\n" +
+                    "    \"minLength\": {\"$ref\": \"#/$defs/nonNegativeIntegerDefault0\"},\n" +
+                    "    \"pattern\": {\n" +
+                    "      \"type\": \"string\",\n" +
+                    "      \"format\": \"regex\"\n" +
+                    "    },\n" +
+                    "    \"maxItems\": {\"$ref\": \"#/$defs/nonNegativeInteger\"},\n" +
+                    "    \"minItems\": {\"$ref\": \"#/$defs/nonNegativeIntegerDefault0\"},\n" +
+                    "    \"uniqueItems\": {\n" +
+                    "      \"type\": \"boolean\",\n" +
+                    "      \"default\": false\n" +
+                    "    },\n" +
+                    "    \"maxContains\": {\"$ref\": \"#/$defs/nonNegativeInteger\"},\n" +
+                    "    \"minContains\": {\n" +
+                    "      \"$ref\": \"#/$defs/nonNegativeInteger\",\n" +
+                    "      \"default\": 1\n" +
+                    "    },\n" +
+                    "    \"maxProperties\": {\"$ref\": \"#/$defs/nonNegativeInteger\"},\n" +
+                    "    \"minProperties\": {\"$ref\": \"#/$defs/nonNegativeIntegerDefault0\"},\n" +
+                    "    \"required\": {\"$ref\": \"#/$defs/stringArray\"},\n" +
+                    "    \"dependentRequired\": {\n" +
+                    "      \"type\": \"object\",\n" +
+                    "      \"additionalProperties\": {\n" +
+                    "        \"$ref\": \"#/$defs/stringArray\"\n" +
+                    "      }\n" +
+                    "    },\n" +
+                    "    \"const\": true,\n" +
+                    "    \"enum\": {\n" +
+                    "      \"type\": \"array\",\n" +
+                    "      \"items\": true\n" +
+                    "    },\n" +
+                    "    \"type\": {\n" +
+                    "      \"anyOf\": [\n" +
+                    "        {\"$ref\": \"#/$defs/simpleTypes\"},\n" +
+                    "        {\n" +
+                    "          \"type\": \"array\",\n" +
+                    "          \"items\": {\"$ref\": \"#/$defs/simpleTypes\"},\n" +
+                    "          \"minItems\": 1,\n" +
+                    "          \"uniqueItems\": true\n" +
+                    "        }\n" +
+                    "      ]\n" +
+                    "    }\n" +
+                    "  },\n" +
+                    "  \"$defs\": {\n" +
+                    "    \"nonNegativeInteger\": {\n" +
+                    "      \"type\": \"integer\",\n" +
+                    "      \"minimum\": 0\n" +
+                    "    },\n" +
+                    "    \"nonNegativeIntegerDefault0\": {\n" +
+                    "      \"$ref\": \"#/$defs/nonNegativeInteger\",\n" +
+                    "      \"default\": 0\n" +
+                    "    },\n" +
+                    "    \"simpleTypes\": {\n" +
+                    "      \"enum\": [\"array\", \"boolean\", \"integer\", \"null\", \"number\", \"object\", \"string\"]\n" +
+                    "    },\n" +
+                    "    \"stringArray\": {\n" +
+                    "      \"type\": \"array\",\n" +
+                    "      \"items\": {\"type\": \"string\"},\n" +
+                    "      \"uniqueItems\": true,\n" +
+                    "      \"default\": []\n" +
+                    "    }\n" +
+                    "  }\n" +
+                    "}\n",
+    };
+
+    static final List<Object> SCHEMAS;
+
+    static {
+        List<Object> schemaObjects;
+        try {
+            schemaObjects = Arrays.stream(SCHEMA_JSONS).map(j -> {
+                try {
+                    return new ObjectMapper().readValue(j, Object.class);
+                }
+                catch (Throwable th) {
+                    throw new RuntimeException(th);
+                }
+            }).collect(Collectors.toList());
+        }
+        catch (Throwable ignored) {
+            schemaObjects = null;
+        }
+        SCHEMAS = schemaObjects;
+    }
+}

--- a/library/src/main/java/net/jimblackler/jsonschemafriend/MetaSchemaDraft202012.java
+++ b/library/src/main/java/net/jimblackler/jsonschemafriend/MetaSchemaDraft202012.java
@@ -1,0 +1,359 @@
+package net.jimblackler.jsonschemafriend;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+class MetaSchemaDraft202012 {
+    private static final String[] SCHEMA_JSONS = new String[] {
+            "{\n" +
+                    "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\",\n" +
+                    "  \"$id\": \"https://json-schema.org/draft/2020-12/schema\",\n" +
+                    "  \"$vocabulary\": {\n" +
+                    "    \"https://json-schema.org/draft/2020-12/vocab/core\": true,\n" +
+                    "    \"https://json-schema.org/draft/2020-12/vocab/applicator\": true,\n" +
+                    "    \"https://json-schema.org/draft/2020-12/vocab/unevaluated\": true,\n" +
+                    "    \"https://json-schema.org/draft/2020-12/vocab/validation\": true,\n" +
+                    "    \"https://json-schema.org/draft/2020-12/vocab/meta-data\": true,\n" +
+                    "    \"https://json-schema.org/draft/2020-12/vocab/format-annotation\": true,\n" +
+                    "    \"https://json-schema.org/draft/2020-12/vocab/content\": true\n" +
+                    "  },\n" +
+                    "  \"$dynamicAnchor\": \"meta\",\n" +
+                    "\n" +
+                    "  \"title\": \"Core and Validation specifications meta-schema\",\n" +
+                    "  \"allOf\": [\n" +
+                    "    {\"$ref\": \"meta/core\"},\n" +
+                    "    {\"$ref\": \"meta/applicator\"},\n" +
+                    "    {\"$ref\": \"meta/unevaluated\"},\n" +
+                    "    {\"$ref\": \"meta/validation\"},\n" +
+                    "    {\"$ref\": \"meta/meta-data\"},\n" +
+                    "    {\"$ref\": \"meta/format-annotation\"},\n" +
+                    "    {\"$ref\": \"meta/content\"}\n" +
+                    "  ],\n" +
+                    "  \"type\": [\"object\", \"boolean\"],\n" +
+                    "  \"$comment\": \"This meta-schema also defines keywords that have appeared in previous drafts in order to prevent incompatible extensions as they remain in common use.\",\n" +
+                    "  \"properties\": {\n" +
+                    "    \"definitions\": {\n" +
+                    "      \"$comment\": \"\\\"definitions\\\" has been replaced by \\\"$defs\\\".\",\n" +
+                    "      \"type\": \"object\",\n" +
+                    "      \"additionalProperties\": {\"$dynamicRef\": \"#meta\"},\n" +
+                    "      \"deprecated\": true,\n" +
+                    "      \"default\": {}\n" +
+                    "    },\n" +
+                    "    \"dependencies\": {\n" +
+                    "      \"$comment\": \"\\\"dependencies\\\" has been split and replaced by \\\"dependentSchemas\\\" and \\\"dependentRequired\\\" in order to serve their differing semantics.\",\n" +
+                    "      \"type\": \"object\",\n" +
+                    "      \"additionalProperties\": {\n" +
+                    "        \"anyOf\": [{\"$dynamicRef\": \"#meta\"}, {\"$ref\": \"meta/validation#/$defs/stringArray\"}]\n" +
+                    "      },\n" +
+                    "      \"deprecated\": true,\n" +
+                    "      \"default\": {}\n" +
+                    "    },\n" +
+                    "    \"$recursiveAnchor\": {\n" +
+                    "      \"$comment\": \"\\\"$recursiveAnchor\\\" has been replaced by \\\"$dynamicAnchor\\\".\",\n" +
+                    "      \"$ref\": \"meta/core#/$defs/anchorString\",\n" +
+                    "      \"deprecated\": true\n" +
+                    "    },\n" +
+                    "    \"$recursiveRef\": {\n" +
+                    "      \"$comment\": \"\\\"$recursiveRef\\\" has been replaced by \\\"$dynamicRef\\\".\",\n" +
+                    "      \"$ref\": \"meta/core#/$defs/uriReferenceString\",\n" +
+                    "      \"deprecated\": true\n" +
+                    "    }\n" +
+                    "  }\n" +
+                    "}\n",
+            "{\n" +
+                    "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\",\n" +
+                    "  \"$id\": \"https://json-schema.org/draft/2020-12/meta/applicator\",\n" +
+                    "  \"$vocabulary\": {\n" +
+                    "    \"https://json-schema.org/draft/2020-12/vocab/applicator\": true\n" +
+                    "  },\n" +
+                    "  \"$dynamicAnchor\": \"meta\",\n" +
+                    "\n" +
+                    "  \"title\": \"Applicator vocabulary meta-schema\",\n" +
+                    "  \"type\": [\"object\", \"boolean\"],\n" +
+                    "  \"properties\": {\n" +
+                    "    \"prefixItems\": {\"$ref\": \"#/$defs/schemaArray\"},\n" +
+                    "    \"items\": {\"$dynamicRef\": \"#meta\"},\n" +
+                    "    \"contains\": {\"$dynamicRef\": \"#meta\"},\n" +
+                    "    \"additionalProperties\": {\"$dynamicRef\": \"#meta\"},\n" +
+                    "    \"properties\": {\n" +
+                    "      \"type\": \"object\",\n" +
+                    "      \"additionalProperties\": {\"$dynamicRef\": \"#meta\"},\n" +
+                    "      \"default\": {}\n" +
+                    "    },\n" +
+                    "    \"patternProperties\": {\n" +
+                    "      \"type\": \"object\",\n" +
+                    "      \"additionalProperties\": {\"$dynamicRef\": \"#meta\"},\n" +
+                    "      \"propertyNames\": {\"format\": \"regex\"},\n" +
+                    "      \"default\": {}\n" +
+                    "    },\n" +
+                    "    \"dependentSchemas\": {\n" +
+                    "      \"type\": \"object\",\n" +
+                    "      \"additionalProperties\": {\"$dynamicRef\": \"#meta\"},\n" +
+                    "      \"default\": {}\n" +
+                    "    },\n" +
+                    "    \"propertyNames\": {\"$dynamicRef\": \"#meta\"},\n" +
+                    "    \"if\": {\"$dynamicRef\": \"#meta\"},\n" +
+                    "    \"then\": {\"$dynamicRef\": \"#meta\"},\n" +
+                    "    \"else\": {\"$dynamicRef\": \"#meta\"},\n" +
+                    "    \"allOf\": {\"$ref\": \"#/$defs/schemaArray\"},\n" +
+                    "    \"anyOf\": {\"$ref\": \"#/$defs/schemaArray\"},\n" +
+                    "    \"oneOf\": {\"$ref\": \"#/$defs/schemaArray\"},\n" +
+                    "    \"not\": {\"$dynamicRef\": \"#meta\"}\n" +
+                    "  },\n" +
+                    "  \"$defs\": {\n" +
+                    "    \"schemaArray\": {\n" +
+                    "      \"type\": \"array\",\n" +
+                    "      \"minItems\": 1,\n" +
+                    "      \"items\": {\"$dynamicRef\": \"#meta\"}\n" +
+                    "    }\n" +
+                    "  }\n" +
+                    "}\n",
+            "{\n" +
+                    "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\",\n" +
+                    "  \"$id\": \"https://json-schema.org/draft/2020-12/meta/content\",\n" +
+                    "  \"$vocabulary\": {\n" +
+                    "    \"https://json-schema.org/draft/2020-12/vocab/content\": true\n" +
+                    "  },\n" +
+                    "  \"$dynamicAnchor\": \"meta\",\n" +
+                    "\n" +
+                    "  \"title\": \"Content vocabulary meta-schema\",\n" +
+                    "\n" +
+                    "  \"type\": [\"object\", \"boolean\"],\n" +
+                    "  \"properties\": {\n" +
+                    "    \"contentEncoding\": {\"type\": \"string\"},\n" +
+                    "    \"contentMediaType\": {\"type\": \"string\"},\n" +
+                    "    \"contentSchema\": {\"$dynamicRef\": \"#meta\"}\n" +
+                    "  }\n" +
+                    "}\n",
+            "{\n" +
+                    "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\",\n" +
+                    "  \"$id\": \"https://json-schema.org/draft/2020-12/meta/core\",\n" +
+                    "  \"$vocabulary\": {\n" +
+                    "    \"https://json-schema.org/draft/2020-12/vocab/core\": true\n" +
+                    "  },\n" +
+                    "  \"$dynamicAnchor\": \"meta\",\n" +
+                    "\n" +
+                    "  \"title\": \"Core vocabulary meta-schema\",\n" +
+                    "  \"type\": [\"object\", \"boolean\"],\n" +
+                    "  \"properties\": {\n" +
+                    "    \"$id\": {\n" +
+                    "      \"$ref\": \"#/$defs/uriReferenceString\",\n" +
+                    "      \"$comment\": \"Non-empty fragments not allowed.\",\n" +
+                    "      \"pattern\": \"^[^#]*#?$\"\n" +
+                    "    },\n" +
+                    "    \"$schema\": {\"$ref\": \"#/$defs/uriString\"},\n" +
+                    "    \"$ref\": {\"$ref\": \"#/$defs/uriReferenceString\"},\n" +
+                    "    \"$anchor\": {\"$ref\": \"#/$defs/anchorString\"},\n" +
+                    "    \"$dynamicRef\": {\"$ref\": \"#/$defs/uriReferenceString\"},\n" +
+                    "    \"$dynamicAnchor\": {\"$ref\": \"#/$defs/anchorString\"},\n" +
+                    "    \"$vocabulary\": {\n" +
+                    "      \"type\": \"object\",\n" +
+                    "      \"propertyNames\": {\"$ref\": \"#/$defs/uriString\"},\n" +
+                    "      \"additionalProperties\": {\n" +
+                    "        \"type\": \"boolean\"\n" +
+                    "      }\n" +
+                    "    },\n" +
+                    "    \"$comment\": {\n" +
+                    "      \"type\": \"string\"\n" +
+                    "    },\n" +
+                    "    \"$defs\": {\n" +
+                    "      \"type\": \"object\",\n" +
+                    "      \"additionalProperties\": {\"$dynamicRef\": \"#meta\"}\n" +
+                    "    }\n" +
+                    "  },\n" +
+                    "  \"$defs\": {\n" +
+                    "    \"anchorString\": {\n" +
+                    "      \"type\": \"string\",\n" +
+                    "      \"pattern\": \"^[A-Za-z_][-A-Za-z0-9._]*$\"\n" +
+                    "    },\n" +
+                    "    \"uriString\": {\n" +
+                    "      \"type\": \"string\",\n" +
+                    "      \"format\": \"uri\"\n" +
+                    "    },\n" +
+                    "    \"uriReferenceString\": {\n" +
+                    "      \"type\": \"string\",\n" +
+                    "      \"format\": \"uri-reference\"\n" +
+                    "    }\n" +
+                    "  }\n" +
+                    "}\n",
+            "{\n" +
+                    "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\",\n" +
+                    "  \"$id\": \"https://json-schema.org/draft/2020-12/meta/format-annotation\",\n" +
+                    "  \"$vocabulary\": {\n" +
+                    "    \"https://json-schema.org/draft/2020-12/vocab/format-annotation\": true\n" +
+                    "  },\n" +
+                    "  \"$dynamicAnchor\": \"meta\",\n" +
+                    "\n" +
+                    "  \"title\": \"Format vocabulary meta-schema for annotation results\",\n" +
+                    "  \"type\": [\"object\", \"boolean\"],\n" +
+                    "  \"properties\": {\n" +
+                    "    \"format\": {\"type\": \"string\"}\n" +
+                    "  }\n" +
+                    "}\n",
+            "{\n" +
+                    "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\",\n" +
+                    "  \"$id\": \"https://json-schema.org/draft/2020-12/meta/meta-data\",\n" +
+                    "  \"$vocabulary\": {\n" +
+                    "    \"https://json-schema.org/draft/2020-12/vocab/meta-data\": true\n" +
+                    "  },\n" +
+                    "  \"$dynamicAnchor\": \"meta\",\n" +
+                    "\n" +
+                    "  \"title\": \"Meta-data vocabulary meta-schema\",\n" +
+                    "\n" +
+                    "  \"type\": [\"object\", \"boolean\"],\n" +
+                    "  \"properties\": {\n" +
+                    "    \"title\": {\n" +
+                    "      \"type\": \"string\"\n" +
+                    "    },\n" +
+                    "    \"description\": {\n" +
+                    "      \"type\": \"string\"\n" +
+                    "    },\n" +
+                    "    \"default\": true,\n" +
+                    "    \"deprecated\": {\n" +
+                    "      \"type\": \"boolean\",\n" +
+                    "      \"default\": false\n" +
+                    "    },\n" +
+                    "    \"readOnly\": {\n" +
+                    "      \"type\": \"boolean\",\n" +
+                    "      \"default\": false\n" +
+                    "    },\n" +
+                    "    \"writeOnly\": {\n" +
+                    "      \"type\": \"boolean\",\n" +
+                    "      \"default\": false\n" +
+                    "    },\n" +
+                    "    \"examples\": {\n" +
+                    "      \"type\": \"array\",\n" +
+                    "      \"items\": true\n" +
+                    "    }\n" +
+                    "  }\n" +
+                    "}\n",
+            "{\n" +
+                    "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\",\n" +
+                    "  \"$id\": \"https://json-schema.org/draft/2020-12/meta/unevaluated\",\n" +
+                    "  \"$vocabulary\": {\n" +
+                    "    \"https://json-schema.org/draft/2020-12/vocab/unevaluated\": true\n" +
+                    "  },\n" +
+                    "  \"$dynamicAnchor\": \"meta\",\n" +
+                    "\n" +
+                    "  \"title\": \"Unevaluated applicator vocabulary meta-schema\",\n" +
+                    "  \"type\": [\"object\", \"boolean\"],\n" +
+                    "  \"properties\": {\n" +
+                    "    \"unevaluatedItems\": {\"$dynamicRef\": \"#meta\"},\n" +
+                    "    \"unevaluatedProperties\": {\"$dynamicRef\": \"#meta\"}\n" +
+                    "  }\n" +
+                    "}\n",
+            "{\n" +
+                    "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\",\n" +
+                    "  \"$id\": \"https://json-schema.org/draft/2020-12/meta/validation\",\n" +
+                    "  \"$vocabulary\": {\n" +
+                    "    \"https://json-schema.org/draft/2020-12/vocab/validation\": true\n" +
+                    "  },\n" +
+                    "  \"$dynamicAnchor\": \"meta\",\n" +
+                    "\n" +
+                    "  \"title\": \"Validation vocabulary meta-schema\",\n" +
+                    "  \"type\": [\"object\", \"boolean\"],\n" +
+                    "  \"properties\": {\n" +
+                    "    \"type\": {\n" +
+                    "      \"anyOf\": [\n" +
+                    "        {\"$ref\": \"#/$defs/simpleTypes\"},\n" +
+                    "        {\n" +
+                    "          \"type\": \"array\",\n" +
+                    "          \"items\": {\"$ref\": \"#/$defs/simpleTypes\"},\n" +
+                    "          \"minItems\": 1,\n" +
+                    "          \"uniqueItems\": true\n" +
+                    "        }\n" +
+                    "      ]\n" +
+                    "    },\n" +
+                    "    \"const\": true,\n" +
+                    "    \"enum\": {\n" +
+                    "      \"type\": \"array\",\n" +
+                    "      \"items\": true\n" +
+                    "    },\n" +
+                    "    \"multipleOf\": {\n" +
+                    "      \"type\": \"number\",\n" +
+                    "      \"exclusiveMinimum\": 0\n" +
+                    "    },\n" +
+                    "    \"maximum\": {\n" +
+                    "      \"type\": \"number\"\n" +
+                    "    },\n" +
+                    "    \"exclusiveMaximum\": {\n" +
+                    "      \"type\": \"number\"\n" +
+                    "    },\n" +
+                    "    \"minimum\": {\n" +
+                    "      \"type\": \"number\"\n" +
+                    "    },\n" +
+                    "    \"exclusiveMinimum\": {\n" +
+                    "      \"type\": \"number\"\n" +
+                    "    },\n" +
+                    "    \"maxLength\": {\"$ref\": \"#/$defs/nonNegativeInteger\"},\n" +
+                    "    \"minLength\": {\"$ref\": \"#/$defs/nonNegativeIntegerDefault0\"},\n" +
+                    "    \"pattern\": {\n" +
+                    "      \"type\": \"string\",\n" +
+                    "      \"format\": \"regex\"\n" +
+                    "    },\n" +
+                    "    \"maxItems\": {\"$ref\": \"#/$defs/nonNegativeInteger\"},\n" +
+                    "    \"minItems\": {\"$ref\": \"#/$defs/nonNegativeIntegerDefault0\"},\n" +
+                    "    \"uniqueItems\": {\n" +
+                    "      \"type\": \"boolean\",\n" +
+                    "      \"default\": false\n" +
+                    "    },\n" +
+                    "    \"maxContains\": {\"$ref\": \"#/$defs/nonNegativeInteger\"},\n" +
+                    "    \"minContains\": {\n" +
+                    "      \"$ref\": \"#/$defs/nonNegativeInteger\",\n" +
+                    "      \"default\": 1\n" +
+                    "    },\n" +
+                    "    \"maxProperties\": {\"$ref\": \"#/$defs/nonNegativeInteger\"},\n" +
+                    "    \"minProperties\": {\"$ref\": \"#/$defs/nonNegativeIntegerDefault0\"},\n" +
+                    "    \"required\": {\"$ref\": \"#/$defs/stringArray\"},\n" +
+                    "    \"dependentRequired\": {\n" +
+                    "      \"type\": \"object\",\n" +
+                    "      \"additionalProperties\": {\n" +
+                    "        \"$ref\": \"#/$defs/stringArray\"\n" +
+                    "      }\n" +
+                    "    }\n" +
+                    "  },\n" +
+                    "  \"$defs\": {\n" +
+                    "    \"nonNegativeInteger\": {\n" +
+                    "      \"type\": \"integer\",\n" +
+                    "      \"minimum\": 0\n" +
+                    "    },\n" +
+                    "    \"nonNegativeIntegerDefault0\": {\n" +
+                    "      \"$ref\": \"#/$defs/nonNegativeInteger\",\n" +
+                    "      \"default\": 0\n" +
+                    "    },\n" +
+                    "    \"simpleTypes\": {\n" +
+                    "      \"enum\": [\"array\", \"boolean\", \"integer\", \"null\", \"number\", \"object\", \"string\"]\n" +
+                    "    },\n" +
+                    "    \"stringArray\": {\n" +
+                    "      \"type\": \"array\",\n" +
+                    "      \"items\": {\"type\": \"string\"},\n" +
+                    "      \"uniqueItems\": true,\n" +
+                    "      \"default\": []\n" +
+                    "    }\n" +
+                    "  }\n" +
+                    "}\n"
+    };
+
+    static final List<Object> SCHEMAS;
+
+    static {
+        List<Object> schemaObjects;
+        try {
+            schemaObjects = Arrays.stream(SCHEMA_JSONS).map(j -> {
+                try {
+                    return new ObjectMapper().readValue(j, Object.class);
+                }
+                catch (Throwable th) {
+                    throw new RuntimeException(th);
+                }
+            }).collect(Collectors.toList());
+        }
+        catch (Throwable ignored) {
+            schemaObjects = null;
+        }
+        SCHEMAS = schemaObjects;
+    }
+}

--- a/library/src/main/java/net/jimblackler/jsonschemafriend/SchemaStore.java
+++ b/library/src/main/java/net/jimblackler/jsonschemafriend/SchemaStore.java
@@ -1,10 +1,7 @@
 package net.jimblackler.jsonschemafriend;
 
 import static net.jimblackler.jsonschemafriend.MetaSchemaDetector.detectMetaSchema;
-import static net.jimblackler.jsonschemafriend.MetaSchemaUris.DRAFT_3;
-import static net.jimblackler.jsonschemafriend.MetaSchemaUris.DRAFT_4;
-import static net.jimblackler.jsonschemafriend.MetaSchemaUris.DRAFT_6;
-import static net.jimblackler.jsonschemafriend.MetaSchemaUris.DRAFT_7;
+import static net.jimblackler.jsonschemafriend.MetaSchemaUris.*;
 import static net.jimblackler.jsonschemafriend.PathUtils.append;
 import static net.jimblackler.jsonschemafriend.PathUtils.baseDocumentFromUri;
 import static net.jimblackler.jsonschemafriend.PathUtils.fixUnescaped;
@@ -75,6 +72,14 @@ public class SchemaStore {
     this.urlRewriter = urlRewriter;
     this.cacheSchema = cacheSchema;
     this.loader = loader;
+
+    // pre-bundle supported drafts
+    store(DRAFT_3, MetaSchemaDraft03.SCHEMA);
+    store(DRAFT_4, MetaSchemaDraft04.SCHEMA);
+    store(DRAFT_6, MetaSchemaDraft06.SCHEMA);
+    store(DRAFT_7, MetaSchemaDraft07.SCHEMA);
+    store(DRAFT_2019_09, MetaSchemaDraft201909.SCHEMAS);
+    store(DRAFT_2020_12, MetaSchemaDraft202012.SCHEMAS);
   }
 
   public Schema loadSchema(Object document) throws GenerationException {


### PR DESCRIPTION
To address latest resolution from json-schema.org community meeting about bundle draft in implementations and prevent them from trying to fetch the meta schemas from the Internet ([link](https://github.com/json-schema-org/community/issues/487)).

This also makes the library not Internet dependent while still allowing it to validate loaded schemas.