### PR TITLE
Remove `println()` from Production code

### DIFF
--- a/library/src/main/java/net/jimblackler/jsonschemafriend/FormatChecker.java
+++ b/library/src/main/java/net/jimblackler/jsonschemafriend/FormatChecker.java
@@ -75,7 +75,6 @@ public class FormatChecker {
           break;
         case "relative-json-pointer":
           Matcher matcher = RELATIVE_JSON_POINTER_PATTERN.matcher(string);
-          System.out.println("groupCount " + matcher.groupCount());
           if (!matcher.find() || matcher.groupCount() != 2) {
             return "Relative JSON Pointer invalid";
           }


### PR DESCRIPTION
Can I propose removing this line, as it spams the logs in production applications.

It simply removing it is not acceptable, then maybe some form of configurable logging framework would be useful?

(Great library BTW!)