### PR TITLE
Update commons-validator:commons-validator to 1.8.0

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -53,7 +53,7 @@ test {
 dependencies {
     implementation 'com.damnhandy:handy-uri-templates:2.1.8'
     implementation 'com.ibm.icu:icu4j:69.1'
-    implementation 'commons-validator:commons-validator:1.7'
+    implementation 'commons-validator:commons-validator:1.8.0'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.12.5'
     implementation 'org.jruby.joni:joni:2.1.41'
     implementation 'org.jsoup:jsoup:1.14.2'


### PR DESCRIPTION
Version 1.7, brings in older commons-collections, which has a security vulnerability: https://security.snyk.io/package/maven/commons-collections:commons-collections/3.2.1