### PR TITLE
Update tests to handle yaml test data and not fail on other types

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -61,4 +61,5 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.8.0'
     testImplementation 'org.junit.jupiter:junit-jupiter-params:5.8.0'
     testImplementation 'org.json:json:20210307'
+    testImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.16.1'
 }

--- a/library/src/test/resources/suites/README.md
+++ b/library/src/test/resources/suites/README.md
@@ -1,3 +1,6 @@
 Update JSON-Schema-Test-Suite with
 
-git submodule update --remote
+First time:
+`git submodule update --init`
+Subsequent times:
+`git submodule update --remote`


### PR DESCRIPTION
Looks like SchemaStore now has test schemas written in yaml and other formats.  I've updated `SchemaStoreTest` to handle the yaml cases, and ignore any others.