### PR TITLE
Enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+registries:
+  maven-central:
+    type: maven-repository
+    url: https://repo.maven.apache.org/maven2/
+  jit-pack:
+    type: maven-repository
+    url: https://jitpack.io
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    open-pull-requests-limit: 50
+    schedule:
+      interval: monthly
+  - package-ecosystem: gradle
+    directory: /
+    registries:
+      - maven-central
+      - jit-pack
+    open-pull-requests-limit: 50
+    schedule:
+      interval: monthly

--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,9 @@
 allprojects {
     repositories {
         mavenLocal()
-        google()
         maven {
             url 'https://jitpack.io'
         }
-        maven {
-            url 'https://repo.maven.apache.org/maven2'
-            name 'Maven Central'
-        }
+        mavenCentral()
     }
 }


### PR DESCRIPTION
Configure GitHub's dependabot to raise PRs to update dependencies.

Also, remove `google` repo, as it's not needed and use Gradle's `mavenCentral()` rather than hand coding.