### PR TITLE
Stop dependabot updating GraalVM dependency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,3 +25,7 @@ updates:
     open-pull-requests-limit: 50
     schedule:
       interval: monthly
+    ignore:
+      - dependency-name: "org.graalvm.*:*"
+        # Stop dependabot wanting to update GraalVM, as it dropped support for Java8 in 22.0.0.
+        update-types: [ "version-update:semver-major" ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: Java CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   build:


### PR DESCRIPTION
...as GraalVM dropped support for Java 8 in 22.0.0. To update past this would require dropping support for Java 8.